### PR TITLE
Fixes error when trying to make api V2 calls

### DIFF
--- a/bingX/api.py
+++ b/bingX/api.py
@@ -33,7 +33,7 @@ class API(object):
         return params
 
     def _signature(self, params, path=None, method=None):
-        if self.api_type != 'perpetual_v1':
+        if self.api_type is not None and 'perpetual' in self.api_type:
             sign = hmac.new(self.api_secret.encode(), params.encode(), 'sha256')
             return f'&signature={sign.hexdigest()}'
         originString = f'{method}{path}{params}'


### PR DESCRIPTION
The condition to create the signature was only checking for perpetual V1. This line should fix the issue for any other perpetual updates to the bingX swap API (e.g. v3, v4, ...)