### PR TITLE
Added demo trading (Not tested)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,27 @@
 <div align="center">
 
-# BingX API Connector Python
+# BingX API Connector Python2
 [![PYPI version][pypi-shield]][pypi-url]
 [![Python version][python-shield]][python-url]
 [![License: GPLv3][license-shield]][license-url]
 
 </div>
+
+## 📌 Please note:
+
+This package is a minor update to [bingX-connector](https://pypi.org/project/bingX-connector/).
+I have opened a pull request as [Ming119](https://github.com/Ming119) instructed in their repoistory. After opening the pull request and mailing them directly and asking them to merge, I got no answer. Therefore, I am publishing this new update with the similar name. This package may be deprecated after they merge.
+
+Keep in mind that for Perpetual v1, no changes were made, so you cannot work demo with that.
+
+Link to [My Pull Request](https://github.com/Ming119/bingX-connector-python/pull/21)
+Link to [Git Repository](https://github.com/demonarch/bingX-connector-python)
+Link to my [GitHub](https://github.com/demonarch)
+
+
+The rest of README.md file provided by Ming119:
+
+
 
 ## 📌 About The Project
 
@@ -22,13 +38,16 @@ pip install -U bingX-connector  # upgrade the package to the latest version
 
 ## 📌 Features
 
-- [x] Standard Contract
+- [x] Standard Contract (Demo)
+- [x] Standard Contract (Real)
 - [ ] Standard Contract Web Socket
-- [x] Spot
+- [x] Spot (Demo)
+- [x] Spot (Real)
 - [ ] Spot Web Socket
 - [x] Perpetual v1
 - [ ] Perpetual v1 Web Socket
-- [x] Perpetual v2
+- [x] Perpetual v2 (Demo)
+- [x] Perpetual v2 (Real)
 - [ ] Perpetual v2 Web Socket
 
 ## 📌 Usage
@@ -36,21 +55,25 @@ pip install -U bingX-connector  # upgrade the package to the latest version
 ### Standard Contract
 ```python
 from bingX.standard import Standard
-
+# by defaul, you're using demo
 client = Standard(api_key, api_secret)
+# or
+client = Standard(api_key, api_secret, mode='demo')
 ```
 
 ### Spot
 ```python
 from bingX.spot import Spot
-
+# by defaul, you're using demo
 client = Spot(api_key, api_secret)
+# or
+client = Spot(api_key, api_secret, mode='demo')
+# use mode='real' to interact with your real account
 ```
 
 ### Perpetual v1
 ```python
 from bingX.perpetual.v1 import Perpetual
-
 client = Perpetual(api_key, api_secret)
 ```
 
@@ -58,7 +81,11 @@ client = Perpetual(api_key, api_secret)
 ```python
 from bingX.perpetual.v2 import Perpetual
 
+# by defaul, you're using demo
 client = Perpetual(api_key, api_secret)
+#or
+client = Perpetual(api_key, api_secret, mode='demo')
+# use mode='real' to interact with your real account
 ```
 > Note that you can not import `Perpetual v1` and `Perpetual v2` at the same time
 
@@ -134,9 +161,12 @@ client = Perpetual(api_key, api_secret)
 
   >  **IMPORTANT**: By submitting a patch, you agree to allow us to license your work under the same license as that used by `bingX-connector-python`
 
-[pypi-shield]: https://img.shields.io/pypi/v/bingX-connector
-[pypi-url]: https://pypi.org/project/bingX-connector/
-[python-shield]: https://img.shields.io/pypi/pyversions/bingX-connector
+[original-github-repo]: https://github.com/Ming119/bingX-connector-python/
+[original-pypi-package]: https://pypi.org/project/bingX-connector/
+[pull-request-url]: https://github.com/Ming119/bingX-connector-python/pull/21
+[pypi-shield]: https://img.shields.io/pypi/v/bingX-connector2
+[pypi-url]: https://pypi.org/project/bingX-connector2/
+[python-shield]: https://img.shields.io/pypi/pyversions/bingX-connector2
 [python-url]: https://www.python.org/downloads/
-[license-shield]: https://img.shields.io/github/license/Ming119/bingX-connector-python
+[license-shield]: https://img.shields.io/github/license/demonarch/bingX-connector-python
 [license-url]: https://www.gnu.org/licenses/gpl-3.0.en.html

--- a/bingX/perpetual/v2/Perpetual.py
+++ b/bingX/perpetual/v2/Perpetual.py
@@ -8,12 +8,21 @@ class Perpetual(API):
     def __init__(self,
         api_key:    str,
         api_secret: str,
+        mode:       str = 'demo'  # Default mode is 'demo'
     ) -> object:
+        if mode == "real":
+            url = "https://open-api.bingx.com"
+        elif mode == "demo":
+            url = "https://open-api-vst.bingx.com"
+        else:
+            raise ValueError("Invalid mode. Mode must be 'real' or 'demo'.")
+        
         super().__init__(
             api_key    = api_key,
             api_secret = api_secret,
-            base_url   = "https://open-api.bingx.com",
+            base_url   = url,
         )
+
 
     def server_time(self) -> dict:
         ''' Get Server Time

--- a/bingX/perpetual/v2/trade.py
+++ b/bingX/perpetual/v2/trade.py
@@ -14,6 +14,9 @@ def trade_order(self,
     quantity:     float = None,
     stopPrice:    float = None,
     recvWindow:   int   = None,
+
+    takeProfit:   float = None,
+    stopLoss:     float = None,
 ) -> dict:
     ''' Place a New Order
     POST /openApi/swap/v2/trade/order
@@ -29,6 +32,9 @@ def trade_order(self,
         "quantity":     quantity,
         "stopPrice":    stopPrice,
         "recvWindow":   recvWindow,
+
+        "takeProfit":  "{\"type\": \"TAKE_PROFIT_MARKET\", \"stopPrice\": %TAKE_PROFIT%,\"price\": %TAKE_PROFIT%,\"workingType\":\"MARK_PRICE\"}".replace("%TAKE_PROFIT%", str(takeProfit)) if takeProfit else None,
+        "stopLoss":    "{\"type\": \"STOP_MARKET\", \"stopPrice\": %STOP_LOSS%,\"price\": %STOP_LOSS%,\"workingType\":\"MARK_PRICE\"}".replace("%STOP_LOSS%", str(stopLoss)) if stopLoss else None,
     })
 
     if 'code' in res and res['code']:

--- a/bingX/perpetual/v2/trade.py
+++ b/bingX/perpetual/v2/trade.py
@@ -33,8 +33,8 @@ def trade_order(self,
         "stopPrice":    stopPrice,
         "recvWindow":   recvWindow,
 
-        "takeProfit":  "{\"type\": \"TAKE_PROFIT_MARKET\", \"stopPrice\": %TAKE_PROFIT%,\"price\": %TAKE_PROFIT%,\"workingType\":\"MARK_PRICE\"}".replace("%TAKE_PROFIT%", str(takeProfit)) if takeProfit else None,
-        "stopLoss":    "{\"type\": \"STOP_MARKET\", \"stopPrice\": %STOP_LOSS%,\"price\": %STOP_LOSS%,\"workingType\":\"MARK_PRICE\"}".replace("%STOP_LOSS%", str(stopLoss)) if stopLoss else None,
+        "takeProfit":  "{\"type\": \"TAKE_PROFIT_MARKET\", \"stopPrice\": %TAKE_PROFIT%,\"price\": %TAKE_PROFIT%,\"workingType\":\"MARK_PRICE\", \"stopGuaranteed\": \"true\"}".replace("%TAKE_PROFIT%", str(takeProfit)) if takeProfit else None,
+        "stopLoss":    "{\"type\": \"STOP_MARKET\", \"stopPrice\": %STOP_LOSS%,\"price\": %STOP_LOSS%,\"workingType\":\"MARK_PRICE\", \"stopGuaranteed\": \"true\"}".replace("%STOP_LOSS%", str(stopLoss)) if stopLoss else None,
     })
 
     if 'code' in res and res['code']:

--- a/bingX/spot/Spot.py
+++ b/bingX/spot/Spot.py
@@ -8,11 +8,19 @@ class Spot(API):
     def __init__(self,
         api_key:    str,
         api_secret: str,
+        mode:       str = 'demo'  # Default mode is 'demo'
     ) -> object:
+        if mode == "real":
+            url = "https://open-api.bingx.com"
+        elif mode == "demo":
+            url = "https://open-api-vst.bingx.com"
+        else:
+            raise ValueError("Invalid mode. Mode must be 'real' or 'demo'.")
+        
         super().__init__(
             api_key    = api_key,
             api_secret = api_secret,
-            base_url   = 'https://open-api.bingx.com',
+            base_url   = url,
         )
 
     # ========== TRADE INTERFACE ==========

--- a/bingX/standard/Standard.py
+++ b/bingX/standard/Standard.py
@@ -8,12 +8,21 @@ class Standard(API):
     def __init__(self,
         api_key:    str,
         api_secret: str,
+        mode:       str = 'demo'  # Default mode is 'demo'
     ) -> object:
+        if mode == "real":
+            url = "https://open-api.bingx.com"
+        elif mode == "demo":
+            url = "https://open-api-vst.bingx.com"
+        else:
+            raise ValueError("Invalid mode. Mode must be 'real' or 'demo'.")
+        
         super().__init__(
             api_key    = api_key,
             api_secret = api_secret,
-            base_url   = "https://open-api.bingx.com",
+            base_url   = url,
         )
+
 
     # ========== STANDARD CONTRACT INTERFACE ==========
     from bingX.standard.trade import (

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-NAME = "bingX-connector"
+NAME = "bingX-connector2"
 VERSION = "0.0.5"
 AUTHOR = "Ming119"
-URL = "https://github.com/Ming119/bingX-connector-python"
+URL = "https://github.com/demonarch/bingX-connector-python"
 
 setuptools.setup(
     name=NAME,

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 NAME = "bingX-connector2"
-VERSION = "0.0.5"
+VERSION = "0.0.8"
 AUTHOR = "Ming119"
 URL = "https://github.com/demonarch/bingX-connector-python"
 


### PR DESCRIPTION
## Demo Trading Guidelines

For real trading on BingX, base url must be (and used to be in python-bingx-connector):

```plaintext
https://open-api.bingx.com
```


To facilitate demo trading on BingX, base URL must be set to the VST api:

```plaintext
https://open-api-vst.bingx.com
```

### Overview

This commit introduces an enhancement to the API client for improved clarity. A new variable named 'mode' has been introduced, set to 'demo' by default. This addition aims to provide developers with better awareness when executing trades; Also enabling them to execute demo trades.

### Usage Instructions

When interacting with your demo account or conducting demo trades, simply utilize the existing default value 'demo' for the 'mode' variable. Conversely, if you intend to execute real trades or interact with your real account, it's imperative to explicitly set the 'mode' variable to 'real'.

### Examples

#### Default mode (demo):

```python
from bingX.perpetual.v2 import Perpetual

# Demo mode by default
client = Perpetual(api_key, api_secret)
balance = client.balance(rec)
print(balance)
positions = client.positions('BTC-USDT')
print(positions)
```

#### Explicitly setting mode to 'demo':

```python
from bingX.perpetual.v2 import Perpetual

# Explicitly setting to demo mode
client = Perpetual(api_key, api_secret, mode='demo')
balance = client.balance(rec)
print(balance)
client.trade_order(
    symbol='BTC-USDT',
    type='market',
    side='buy',
    quantity=0.001,
)
```

#### Explicitly setting mode to 'real' (For executing real trades or interacting with real accounts), please use with awareness in your responsibility:

```python
from bingX.perpetual.v2 import Perpetual

# Explicitly setting to real mode
client = Perpetual(api_key, api_secret, mode='real')
balance = client.balance(rec)
print(balance)
client.trade_order(
    symbol='BTC-USDT',
    type='market',
    side='buy',
    quantity=0.001,
)
```
